### PR TITLE
Cancerify now supports Zalgofy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Requires the 'emoji' package and the 'bidict' package.
 4. Cancerous fonts
 5. B-ify
 6. n't-ify
+7. Zalgofy (might not work in your terminal, or on all browsers)
 
 # Installation
 
@@ -22,26 +23,30 @@ Make sure the pip binary installation directory is in your PATH
 Cancerify can be used in two ways: either as a command line script or from another Python script
 
 ## Using from command line
+
 ```
-cancerify -f filename -c -l -b -e -n 30 -t -T antonym_file
+usage: cancerify [-h] [-e] [--emojify] [-n R] [-f FILENAME] [-c] [-l] [-p P] [-b] [-x] [-o] [-t] [-T NTFILE] [-z] [--zintup ZINTUP] [--zintmid ZINTMID] [--zintdown ZINTDOWN] [--zintrand ZINTRAND]
+
+optional arguments:
+  -h, --help           show this help message and exit
+  -e                   Use emojis
+  --emojify            Use emojis
+  -n R                 max number of emojis
+  -f FILENAME          File name
+  -c                   Use letters
+  -l                   use lenny faces
+  -p P                 Max number of lennies
+  -b                   Replace "b" with B emoji
+  -x                   Prettify
+  -o                   Oofify
+  -t                   Antonymn't-ify
+  -T NTFILE            Antonymn't-ify files
+  -z                   Zalgofy
+  --zintup ZINTUP      Zalgo intenisty up
+  --zintmid ZINTMID    Zalgo intensity mid
+  --zintdown ZINTDOWN  Zalgo intensity down
+  --zintrand ZINTRAND  Use random intensity
 ```
-
--f the filename from where to read the text, leave empty for reading from stdin
-
--l lennify, randomly insert lenny faces
-
--b b-fy, replace 'b' or 'B' with B emoji
-
--e emojify, insert randomly random number of emojis
-
--n max number of consecutive emojis
-
--c use cancerous fonts (currently greek and coptik)
-
--t Use n't-ify 
-
--T Antonym file
-
 If no file is specified, Cancerify will read from stdin. Press Ctrl-D to stop.
 
 ## Using from another file:
@@ -65,6 +70,11 @@ Next, instantiate a CancerifierArgument from a dictionary. The dictionary can ha
 9.  oof-ify: True or False,
 10. antonym: True or False,
 11. antonym_file: Path to antonym file
+12. zalgofy: Zalgofy - True or False
+13. zintup: Intensity of zalgo texts going up
+14. zintmid: Intensity of zalgo texts over characters
+15. zintdown: Intensity of zalgo texts going down
+16. zintrand: If True, for each position, a random number of zalgo texts less than the corresponding intensity will be used, else exactly that many texts will be used.
 
 ```
 args = CancerifierArgument({'use_emoji': True, 'max_emoji': 40, 'prettify': True, 'content': 's  faf safa   gfagag'})

--- a/bin/cancerify
+++ b/bin/cancerify
@@ -17,6 +17,11 @@ if __name__ == "__main__":
     parser.add_argument('-o',action = 'store_true',dest = 'oof', default = False, help = 'Oofify')
     parser.add_argument('-t',action = 'store_true',dest = 'nt', default = False, help = 'Antonymn\'t-ify')
     parser.add_argument('-T',action = 'store',dest = 'ntfile', default = "", help = 'Antonymn\'t-ify files')
+    parser.add_argument('-z',action = 'store_true',dest = 'zalgofy', default = False, help = 'Zalgofy')
+    parser.add_argument('--zintup',action = 'store',dest = 'zintup', type=int, default = 5, help = 'Zalgo intenisty up')
+    parser.add_argument('--zintmid',action = 'store',dest = 'zintmid', type=int, default = 5, help = 'Zalgo intensity mid')
+    parser.add_argument('--zintdown',action = 'store',dest = 'zintdown', type=int, default = 5, help = 'Zalgo intensity down')
+    parser.add_argument('--zintrand',action = 'store',dest = 'zintrand', default = True, help = 'Use random intensity')
     args = parser.parse_args()
 
     f = None

--- a/cancerify/cancerify.py
+++ b/cancerify/cancerify.py
@@ -19,7 +19,12 @@ class CancerifierArgument:
             "prettify": ("x", False),
             "oof-ify": ("oof", False),
             "antonym": ("nt", False),
-            "antonym_file": ("ntfile", None)
+            "antonym_file": ("ntfile", None),
+            "zalgofy":("zalgofy", False),
+            "zintup": ("zintup", 5),
+            "zintmid": ("zintmid", 5),
+            "zintdown": ("zintdown", 5),
+            "zintrand": ("zintrand", True)
         }
 
         for k,v in map.items():
@@ -54,6 +59,19 @@ class Cancerifier:
 
         unicode_greek_coptic  =['\u03B1', '\u03B2', '\u03DA', 'd', '\u03B5', '\u03DC', 'g', '\u03E7', '\u03CA', '\u03F3', '\u03BA', '\u03B9', '\u03FB', '\u03F0', '\u03D9', '\u03C1', '\u03E4', 'r', '\u03E9', '\u03EF', '\u03B0', '\u03BD', '\u03E3', '\u03C7', '\u03AB', '\u03B6']
 
+        zalgo_marks_above = ['\u0300', '\u0301', '\u0302', '\u0303', '\u0304', '\u0305', '\u0306', '\u0307', '\u0308', '\u0309', '\u030A', '\u030B', '\u030C', '\u030D', '\u030E', '\u030F', 
+                             '\u0310', '\u0311', '\u0312', '\u0313', '\u0314', '\u0315', '\u031A', '\u031B', '\u033D', '\u033E', '\u033F', '\u0340', '\u0341', '\u3042', '\u3043', '\u3044', '\u3046', '\u034A', '\u034B', 
+                             '\u034C', '\u0350', '\u0351', '\u0352', '\u0357', '\u0358', '\u035B', '\u035D', '\u035E', '\u0360', '\u0361' ]
+        
+        zalgo_marks_below = ['\u0316', '\u0317', '\u0318', '\u0319', '\u031C', '\u031D', '\u031E', '\u031F', '\u0320', '\u0321', '\u0322', '\u0323', '\u0324', '\u0325', '\u0326', '\u0327', '\u0328', 
+                             '\u0329', '\u032A', '\u032B', '\u032C', '\u032D', '\u032E', '\u032F', '\u0330', '\u0331', '\u0332', '\u0333', '\u0339', '\u033A', '\u033B', 
+                             '\u033C', '\u0345', '\u0347', '\u0348', '\u0349', '\u034D', '\u034E', '\u0353', '\u0354', '\u0355', '\u0356', '\u0359', '\u035A', '\u035C', '\u035F', '\u0362' ]
+        
+        zalgo_marks_over = [ '\u0334', '\u0335', '\u0336', '\u0337', '\u0338' ]
+        
+        zalgo_marks_latin_above = [ '\u0363', '\u0364', '\u0365', '\u0366', '\u0367', '\u0368', '\u0369', '\u036A', '\u036B', '\u036C', '\u036D', '\u036E', '\u036F' ]
+        
+        zalgo_position_dict = { "up": zalgo_marks_above + zalgo_marks_latin_above, "mid": zalgo_marks_over, "down": zalgo_marks_below }
         #List of the list of letters
         letter_list = [unicode_cyrillic_capital, unicode_greek_coptic]
 
@@ -106,6 +124,27 @@ class Cancerifier:
                 #Replace the spaces randomly with oof
                 if random.randint(1,5) == 5 and c == ' ' and args.oof:
                     result += ' oof '
+                    
+            # Zalgo-fy after everything else is done
+            
+        
+            if args.zalgofy:
+                intensities = { "up": args.zintup, "mid": args.zintmid, "down": args.zintdown }
+                result__ = ""
+                for c in result:
+                    zalgo_counts = { k: 0 for k in zalgo_position_dict.keys() }
+                    for position in zalgo_position_dict.keys():
+                        zalgo_counts[position] = random.randint(0, intensities[position]) if args.zintrand else intensities[position]
+                    result__ += c
+                    
+                    for position in zalgo_position_dict.keys():
+                        chars = zalgo_position_dict[position]
+                        count = intensities[position]
+                        res_ = random.sample(chars, count)
+                        random.shuffle(res_)
+                        
+                        result__ += ''.join(res_)
+                result = result__
             return result
         else:
             #Prettify

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cancerify",
-    version="0.0.5",
+    version="1.0.0",
     author="Aniket Bhattacharyea",
     author_email="i_abh_esc_wq@protonmail.com",
     description="Turn an innocent text into torturous hell",


### PR DESCRIPTION
Cancerify now supports Zalgofy. Use the -z flag to make your texts even more torturous. Might not work in your terminal, or all browsers.